### PR TITLE
Add project command to remove CMake warning

### DIFF
--- a/exercises/template/CMakeLists.txt
+++ b/exercises/template/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required ( VERSION 2.8.5 )
+cmake_minimum_required ( VERSION 3.14 )
+
+project(newstarter)
 
 add_subdirectory ( ex01_basics )
 add_subdirectory ( ex02_oo_basics )


### PR DESCRIPTION
CMake has started producing a warning since v3.16 if you don't specify a project command at the top of the master CMakeLists.txt file:
![CMakeWarning](https://user-images.githubusercontent.com/56295817/87907206-0cdf8a80-ca5c-11ea-8730-4a7ae8c158ca.PNG)

So thought I'd resolve this to avoid any confusion.
Also moved the minimum required version on to match the version required by the CMakeLists in the main Mantid repository